### PR TITLE
deb/flo: Remove density from PRODUCT_AAPT_CONFIG

### DIFF
--- a/device-common.mk
+++ b/device-common.mk
@@ -31,11 +31,7 @@ PRODUCT_COPY_FILES := \
 	$(LOCAL_KERNEL):kernel
 endif
 
-# This device is xhdpi.  However the platform doesn't
-# currently contain all of the bitmaps at xhdpi density so
-# we do this little trick to fall back to the hdpi version
-# if the xhdpi doesn't exist.
-PRODUCT_AAPT_CONFIG := normal large hdpi xhdpi
+PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREF_CONFIG := xhdpi
 
 PRODUCT_PACKAGES := \


### PR DESCRIPTION
AAPT ignores densities in PRODUCT_AAPT_CONFIG.
The use of PRODUCT_AAPT_PREF_CONFIG for density is
encouraged, as AAPT is able to determine the fallback
density to use if a resource of the specified density
does not exist.

Change-Id: I581fe61e1f2afcf0f0b490ba49ebee55f47053c6