### PR TITLE
flo: Fix apps2d to usb storage

### DIFF
--- a/fstab.flo
+++ b/fstab.flo
@@ -21,4 +21,4 @@
 /dev/block/platform/msm_sdcc.1/by-name/tzb          /tzb            emmc    defaults                                                                     defaults
 /dev/block/platform/msm_sdcc.1/by-name/rpmb         /rpmb           emmc    defaults                                                                     defaults
 /dev/block/platform/msm_sdcc.1/by-name/abootb       /abootb         emmc    defaults                                                                     defaults
-/devices/platform/msm_hsusb_host/usb                auto            auto    defaults                                                                     voldmanaged=usbdisk:auto
+/devices/platform/msm_hsusb_host/usb                auto            auto    defaults                                                                     voldmanaged=usbdisk:auto,noemulatedsd


### PR DESCRIPTION
While this may not be a very good idea to use (do you really want
to have a usb stick sticking out of your phone??), the current
fstab is incorrect and needs to be fixed.

Removable storage is always noemulatedsd (and defined as such
in storage_list.xml).  The fstab should be consistent with the
rest of android.

Change-Id: I09a2eb33382d5c9afb97ebb9c506ac81c22b266d